### PR TITLE
Prevent bumping PHP patch versions

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -37,7 +37,7 @@
       "matchPackageNames": [
         "php"
       ],
-      "matchNewValue": "/~\d+\\.\d+\\.0/",
+      "matchNewValue": "/~\\d+\\.\\d+\\.0/",
       "extends": [
         ":automergeDisabled",
         ":automergePr"

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -37,6 +37,7 @@
       "matchPackageNames": [
         "php"
       ],
+      "matchNewValue": "/~\d+\\.\d+\\.0/",
       "extends": [
         ":automergeDisabled",
         ":automergePr"


### PR DESCRIPTION
The entire CI toolchain generally gets bumped with minor PHP versions only, while patch PHP versions don't need regular bumping.

This prevents continuously broken builds due to PHP not being up-to-date in CI tooling (which happens often).

Refs:

* https://discord.com/channels/1090672946370052166/1091081297759309926/1484548563701600306
* https://github.com/WyriHaximus/renovate-config/blob/4bbf2d05f90a6ee005be9bf49d5d9ed6dccc9490/php-package.json
* https://github.com/WyriHaximus/renovate-config/blob/4bbf2d05f90a6ee005be9bf49d5d9ed6dccc9490/composer/do-not-update-php.json
* https://docs.renovatebot.com/configuration-options/#packagerulesmatchnewvalue

Thanks to @WyriHaximus for guidance here :-)